### PR TITLE
Fix fatal error in Totara when updating user profile.

### DIFF
--- a/local/autogroup/classes/sort_module/primary_position.php
+++ b/local/autogroup/classes/sort_module/primary_position.php
@@ -78,6 +78,9 @@ if(isset($CFG->totara_build) && (int) $CFG->totara_build > 20150302) {
          */
         public function eligible_groups_for_user(stdClass $user)
         {
+            global $CFG;
+            require_once("{$CFG->dirroot}/totara/hierarchy/prefix/position/lib.php");
+
             $field = $this->field . 'id';
 
             // Attempt to load the assignment


### PR DESCRIPTION
\local_autogroup\sort_module\primary_position::eligible_groups_for_user() was instantiating a \position_assignment object without necessarily loading the class definition.
